### PR TITLE
Add Security Headers for Production-Ready Security

### DIFF
--- a/README.md
+++ b/README.md
@@ -103,6 +103,20 @@ For complete setup and development workflow, follow the step-by-step guide:
 - **E2E tests**: Playwright for full user flow testing
 - **Coverage reporting**: Built-in code coverage tools
 
+### Security
+
+- **Security headers**: Production-ready headers configured by default
+  - **X-Frame-Options**: Prevents clickjacking attacks
+  - **X-Content-Type-Options**: Prevents MIME type sniffing
+  - **Content-Security-Policy**: Restricts resource loading (allows Stripe & Application Insights)
+  - **Referrer-Policy**: Controls referrer information leakage
+  - **Permissions-Policy**: Restricts browser API access (camera, microphone, geolocation)
+- **SQL injection protection**: Kysely's parameterized queries prevent SQL injection
+- **Password security**: bcrypt hashing for password storage
+- **Session security**: NextAuth JWT with secure cookies
+- **Rate limiting**: Built-in protection for checkout endpoints
+- **Input validation**: Zod schemas for type-safe validation
+
 ## 🚀 Deployment
 
 See [DEPLOYMENT.md](docs/DEPLOYMENT.md) for detailed deployment instructions and workflow.

--- a/next.config.js
+++ b/next.config.js
@@ -15,6 +15,49 @@ const nextConfig = {
   // Allow development origins dynamically
   // Uses NEXTAUTH_URL host in development, empty in production
   allowedDevOrigins: isDev ? [devOriginHost] : [],
+
+  // Security headers for all routes
+  // Provides secure-by-default configuration for the template
+  async headers() {
+    return [
+      {
+        source: '/:path*',
+        headers: [
+          // Prevent clickjacking attacks
+          { key: 'X-Frame-Options', value: 'DENY' },
+          
+          // Prevent MIME type sniffing
+          { key: 'X-Content-Type-Options', value: 'nosniff' },
+          
+          // Control referrer information leakage
+          { key: 'Referrer-Policy', value: 'strict-origin-when-cross-origin' },
+          
+          // Enable XSS protection (legacy but still useful)
+          { key: 'X-XSS-Protection', value: '1; mode=block' },
+          
+          // Restrict browser features (camera, microphone, geolocation)
+          { key: 'Permissions-Policy', value: 'camera=(), microphone=(), geolocation=()' },
+          
+          // Content Security Policy
+          // Allows Stripe for checkout, Application Insights for monitoring
+          // 'unsafe-inline' and 'unsafe-eval' required for Next.js hydration
+          {
+            key: 'Content-Security-Policy',
+            value: [
+              "default-src 'self'",
+              "script-src 'self' 'unsafe-inline' 'unsafe-eval' js.stripe.com",
+              "style-src 'self' 'unsafe-inline'",
+              "img-src 'self' data: blob: *.stripe.com",
+              "font-src 'self'",
+              "connect-src 'self' *.stripe.com *.applicationinsights.azure.com",
+              "frame-src js.stripe.com",
+            ].join('; '),
+          },
+          // Note: HSTS (Strict-Transport-Security) is handled by Azure/hosting layer in production
+        ],
+      },
+    ]
+  },
 }
 module.exports = nextConfig
 

--- a/tests/e2e/security-headers.spec.ts
+++ b/tests/e2e/security-headers.spec.ts
@@ -1,0 +1,107 @@
+import { test, expect } from '@playwright/test'
+
+/**
+ * E2E tests for security headers
+ * Verifies that security headers are actually returned by the server
+ * These tests require a running dev server (pnpm dev)
+ */
+
+test.describe('Security Headers', () => {
+  test('should return X-Frame-Options header', async ({ page }) => {
+    const response = await page.goto('/')
+    
+    expect(response).toBeTruthy()
+    const headers = response?.headers() || {}
+    
+    expect(headers['x-frame-options']).toBe('DENY')
+  })
+
+  test('should return X-Content-Type-Options header', async ({ page }) => {
+    const response = await page.goto('/')
+    
+    expect(response).toBeTruthy()
+    const headers = response?.headers() || {}
+    
+    expect(headers['x-content-type-options']).toBe('nosniff')
+  })
+
+  test('should return Referrer-Policy header', async ({ page }) => {
+    const response = await page.goto('/')
+    
+    expect(response).toBeTruthy()
+    const headers = response?.headers() || {}
+    
+    expect(headers['referrer-policy']).toBe('strict-origin-when-cross-origin')
+  })
+
+  test('should return X-XSS-Protection header', async ({ page }) => {
+    const response = await page.goto('/')
+    
+    expect(response).toBeTruthy()
+    const headers = response?.headers() || {}
+    
+    expect(headers['x-xss-protection']).toBe('1; mode=block')
+  })
+
+  test('should return Permissions-Policy header', async ({ page }) => {
+    const response = await page.goto('/')
+    
+    expect(response).toBeTruthy()
+    const headers = response?.headers() || {}
+    
+    const permissionsPolicy = headers['permissions-policy']
+    expect(permissionsPolicy).toBeTruthy()
+    expect(permissionsPolicy).toContain('camera=()')
+    expect(permissionsPolicy).toContain('microphone=()')
+    expect(permissionsPolicy).toContain('geolocation=()')
+  })
+
+  test('should return Content-Security-Policy header', async ({ page }) => {
+    const response = await page.goto('/')
+    
+    expect(response).toBeTruthy()
+    const headers = response?.headers() || {}
+    
+    const csp = headers['content-security-policy']
+    expect(csp).toBeTruthy()
+    
+    // Should allow self-origin
+    expect(csp).toContain("default-src 'self'")
+    
+    // Should allow Stripe
+    expect(csp).toContain('js.stripe.com')
+    
+    // Should allow Application Insights
+    expect(csp).toContain('*.applicationinsights.azure.com')
+  })
+
+  test('should return security headers on API routes', async ({ page }) => {
+    // Test that headers are applied to API routes too
+    const response = await page.goto('/api/health')
+    
+    expect(response).toBeTruthy()
+    const headers = response?.headers() || {}
+    
+    // Should have security headers even on API routes
+    expect(headers['x-frame-options']).toBe('DENY')
+    expect(headers['x-content-type-options']).toBe('nosniff')
+  })
+
+  test('should return security headers on all routes', async ({ page }) => {
+    // Test multiple routes to ensure headers are applied everywhere
+    const routes = ['/', '/auth/signup', '/dashboard', '/profile']
+    
+    for (const route of routes) {
+      const response = await page.goto(route)
+      
+      if (response) {
+        const headers = response.headers()
+        
+        // All routes should have security headers
+        expect(headers['x-frame-options']).toBe('DENY')
+        expect(headers['x-content-type-options']).toBe('nosniff')
+      }
+    }
+  })
+})
+

--- a/tests/integration/config/__tests__/security-headers.test.ts
+++ b/tests/integration/config/__tests__/security-headers.test.ts
@@ -1,0 +1,145 @@
+import { describe, it, expect } from 'vitest'
+import { createRequire } from 'module'
+
+const require = createRequire(import.meta.url)
+
+/**
+ * Integration test for security headers configuration
+ * Verifies that next.config.js headers() function returns correct security headers
+ * This ensures the template is secure by default
+ */
+
+describe('Security Headers Configuration', () => {
+  // Get the headers function from next.config.js
+  // Clear cache to ensure fresh import
+  // Path: tests/integration/config/__tests__/ -> root (4 levels up)
+  const configPath = require.resolve('../../../../next.config.js')
+  delete require.cache[configPath]
+  const nextConfig = require('../../../../next.config.js')
+  const headersConfig = nextConfig.headers || (() => Promise.resolve([]))
+
+  it('should return headers configuration for all routes', async () => {
+    const headers = await headersConfig()
+    
+    // Should have at least one header configuration
+    expect(headers).toBeDefined()
+    expect(Array.isArray(headers)).toBe(true)
+    expect(headers.length).toBeGreaterThan(0)
+    
+    // Should have a catch-all route pattern
+    const catchAllRoute = headers.find(h => h.source === '/:path*')
+    expect(catchAllRoute).toBeDefined()
+  })
+
+  it('should include X-Frame-Options header set to DENY', async () => {
+    const headers = await headersConfig()
+    const catchAllRoute = headers.find(h => h.source === '/:path*')
+    
+    expect(catchAllRoute).toBeDefined()
+    
+    const frameOptions = catchAllRoute?.headers.find(h => h.key === 'X-Frame-Options')
+    expect(frameOptions).toBeDefined()
+    expect(frameOptions?.value).toBe('DENY')
+  })
+
+  it('should include X-Content-Type-Options header set to nosniff', async () => {
+    const headers = await headersConfig()
+    const catchAllRoute = headers.find(h => h.source === '/:path*')
+    
+    expect(catchAllRoute).toBeDefined()
+    
+    const contentTypeOptions = catchAllRoute?.headers.find(h => h.key === 'X-Content-Type-Options')
+    expect(contentTypeOptions).toBeDefined()
+    expect(contentTypeOptions?.value).toBe('nosniff')
+  })
+
+  it('should include Referrer-Policy header', async () => {
+    const headers = await headersConfig()
+    const catchAllRoute = headers.find(h => h.source === '/:path*')
+    
+    expect(catchAllRoute).toBeDefined()
+    
+    const referrerPolicy = catchAllRoute?.headers.find(h => h.key === 'Referrer-Policy')
+    expect(referrerPolicy).toBeDefined()
+    expect(referrerPolicy?.value).toBe('strict-origin-when-cross-origin')
+  })
+
+  it('should include X-XSS-Protection header', async () => {
+    const headers = await headersConfig()
+    const catchAllRoute = headers.find(h => h.source === '/:path*')
+    
+    expect(catchAllRoute).toBeDefined()
+    
+    const xssProtection = catchAllRoute?.headers.find(h => h.key === 'X-XSS-Protection')
+    expect(xssProtection).toBeDefined()
+    expect(xssProtection?.value).toBe('1; mode=block')
+  })
+
+  it('should include Permissions-Policy header', async () => {
+    const headers = await headersConfig()
+    const catchAllRoute = headers.find(h => h.source === '/:path*')
+    
+    expect(catchAllRoute).toBeDefined()
+    
+    const permissionsPolicy = catchAllRoute?.headers.find(h => h.key === 'Permissions-Policy')
+    expect(permissionsPolicy).toBeDefined()
+    expect(permissionsPolicy?.value).toContain('camera=()')
+    expect(permissionsPolicy?.value).toContain('microphone=()')
+    expect(permissionsPolicy?.value).toContain('geolocation=()')
+  })
+
+  it('should include Content-Security-Policy header', async () => {
+    const headers = await headersConfig()
+    const catchAllRoute = headers.find(h => h.source === '/:path*')
+    
+    expect(catchAllRoute).toBeDefined()
+    
+    const csp = catchAllRoute?.headers.find(h => h.key === 'Content-Security-Policy')
+    expect(csp).toBeDefined()
+    expect(csp?.value).toBeTruthy()
+    
+    const cspValue = csp?.value || ''
+    
+    // Should allow self-origin
+    expect(cspValue).toContain("default-src 'self'")
+    
+    // Should allow Stripe scripts
+    expect(cspValue).toContain('js.stripe.com')
+    
+    // Should allow Application Insights
+    expect(cspValue).toContain('*.applicationinsights.azure.com')
+    
+    // Should allow Stripe frames
+    expect(cspValue).toContain('frame-src js.stripe.com')
+    
+    // Should allow inline scripts/styles for Next.js hydration
+    expect(cspValue).toContain("'unsafe-inline'")
+  })
+
+  it('should allow Stripe domains in CSP', async () => {
+    const headers = await headersConfig()
+    const catchAllRoute = headers.find(h => h.source === '/:path*')
+    const csp = catchAllRoute?.headers.find(h => h.key === 'Content-Security-Policy')
+    const cspValue = csp?.value || ''
+    
+    // Check for Stripe script source
+    expect(cspValue).toMatch(/script-src[^;]*js\.stripe\.com/)
+    
+    // Check for Stripe image source
+    expect(cspValue).toMatch(/img-src[^;]*\*\.stripe\.com/)
+    
+    // Check for Stripe connect source
+    expect(cspValue).toMatch(/connect-src[^;]*\*\.stripe\.com/)
+  })
+
+  it('should allow Application Insights in CSP', async () => {
+    const headers = await headersConfig()
+    const catchAllRoute = headers.find(h => h.source === '/:path*')
+    const csp = catchAllRoute?.headers.find(h => h.key === 'Content-Security-Policy')
+    const cspValue = csp?.value || ''
+    
+    // Should allow Application Insights for monitoring
+    expect(cspValue).toMatch(/connect-src[^;]*\*\.applicationinsights\.azure\.com/)
+  })
+})
+


### PR DESCRIPTION
Adds security headers configuration to make the template secure by default. All security headers are configured in `next.config.js` and automatically applied to all routes. Documentation and testing added as well.